### PR TITLE
fix: restore vertical scroll for manga reader (#79)

### DIFF
--- a/src/screens/mangaReaderScreen.tsx
+++ b/src/screens/mangaReaderScreen.tsx
@@ -263,6 +263,7 @@ export function MangaReaderScreen() {
                         )}
                     </Flex>
                     <Box
+                        data-lenis-prevent
                         className="custom-scrollbar"
                         sx={{
                             width: '100%',


### PR DESCRIPTION

https://github.com/user-attachments/assets/5c46ed8b-a836-40f1-895e-83d786955645

